### PR TITLE
Add pie chart section

### DIFF
--- a/components/sections/ParagraphSection.tsx
+++ b/components/sections/ParagraphSection.tsx
@@ -1,14 +1,14 @@
 import { PortableText } from 'next-sanity';
-import { Section } from '../../utils/types';
+import { SectionParagraph } from '../../utils/types';
 
 type Props = {
-  section: Section;
+  section: SectionParagraph;
 };
 
 const ParagraphSection = ({ section }: Props) => {
   return (
     <div className="section">
-      <h2>{section.title}</h2>
+      {section.title && <h2>{section.title}</h2>}
       <PortableText value={section.paragraphs} />
     </div>
   );

--- a/components/sections/PieChartSection.tsx
+++ b/components/sections/PieChartSection.tsx
@@ -1,0 +1,57 @@
+import { PieChart, Pie, Tooltip, Cell, ResponsiveContainer } from 'recharts';
+import { ChartValue, SectionPieChart } from '../../utils/types';
+
+const renderLabel = (entry: ChartValue) => `${entry.label} – ${entry.value} % `;
+
+const colorScale = [
+  'rgb(72, 207, 212)',
+  'rgb(33, 161, 166)',
+  'rgb(13, 124, 128)',
+  'rgb(202, 101, 165)',
+  'rgb(217, 110, 110)',
+  'rgb(200, 85, 85)',
+  'rgb(204, 204, 0)',
+  'rgb(168, 217, 110)',
+  'rgb(200, 200, 200)',
+];
+
+type Props = {
+  section: SectionPieChart;
+};
+
+const PieChartSection = ({ section }: Props) => {
+  const parsedUpdatedAt = new Date(section.updatedAt);
+
+  return (
+    <div className="section">
+      {section.title && <h2>{section.title}</h2>}
+      <ResponsiveContainer width="100%" height={300}>
+        <PieChart width={1000} height={280}>
+          <Pie
+            data={section.values}
+            nameKey={'label'}
+            dataKey={'value'}
+            innerRadius={30}
+            outerRadius={100}
+            label={renderLabel}
+          >
+            {section.values.map((entry, i) => (
+              <Cell
+                key={entry.label}
+                fill={colorScale[i % colorScale.length]}
+              />
+            ))}
+          </Pie>
+          <Tooltip />
+        </PieChart>
+      </ResponsiveContainer>
+      {section.updatedAt && (
+        <p>
+          Tallene er sist oppdatert {parsedUpdatedAt.toLocaleString('no-NB')}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default PieChartSection;

--- a/components/sections/index.tsx
+++ b/components/sections/index.tsx
@@ -1,5 +1,6 @@
 import { Section } from '../../utils/types';
 import ParagraphSection from './ParagraphSection';
+import PieChartSection from './PieChartSection';
 
 type Props = {
   sections: Section[];
@@ -9,6 +10,8 @@ const Sections = ({ sections }: Props) => {
   return sections.map((section) => {
     if (section._type === 'paragraph-section')
       return <ParagraphSection key={section._key} section={section} />;
+    if (section._type === 'piechart-section')
+      return <PieChartSection key={section._key} section={section} />;
     return null;
   });
 };

--- a/sanity/schemas/page.ts
+++ b/sanity/schemas/page.ts
@@ -1,3 +1,9 @@
+import {
+  Progress75Icon,
+  Progress50Icon,
+  BlockContentIcon,
+} from '@sanity/icons';
+
 const PageSchema = {
   name: 'page',
   type: 'document',
@@ -29,6 +35,7 @@ const PageSchema = {
           name: 'paragraph-section',
           title: 'Seksjon',
           type: 'object',
+          icon: BlockContentIcon,
           fields: [
             {
               name: 'title',
@@ -42,6 +49,70 @@ const PageSchema = {
               of: [{ type: 'block' }, { type: 'image' }],
             },
           ],
+        },
+        {
+          name: 'piechart-section',
+          title: 'Kakediagram',
+          type: 'object',
+          icon: Progress75Icon,
+          fields: [
+            {
+              name: 'title',
+              title: 'Tittel',
+              type: 'string',
+            },
+            {
+              name: 'updatedAt',
+              title: 'Dato for siste oppdatering av tallene',
+              type: 'datetime',
+            },
+            {
+              name: 'values',
+              title: 'Verdier',
+              type: 'array',
+              of: [
+                {
+                  type: 'object',
+                  name: 'value-object',
+                  title: 'Verdi',
+                  icon: Progress50Icon,
+                  fields: [
+                    { name: 'label', title: 'Tekst', type: 'string' },
+                    {
+                      name: 'value',
+                      title: 'Verdi (i prosent)',
+                      type: 'number',
+                    },
+                  ],
+                  preview: {
+                    select: {
+                      label: 'label',
+                      value: 'value',
+                    },
+                    prepare(selection: { label: string; value: number }) {
+                      const { label, value } = selection;
+                      return {
+                        title: `${label} - ${value}%`,
+                      };
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+          preview: {
+            select: {
+              title: 'title',
+              updatedAt: 'updatedAt',
+            },
+            prepare(selection: { title: string; updatedAt: string }) {
+              const { title, updatedAt } = selection;
+              const updatedDate = new Date(updatedAt);
+              return {
+                title: `${title} (sist oppdatert ${updatedDate.toLocaleDateString('no-NB')})`,
+              };
+            },
+          },
         },
       ],
     },

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -11,13 +11,25 @@ type SectionBase = {
   _key: string;
 };
 
-export type ParagraphSection = SectionBase & {
+export type SectionParagraph = SectionBase & {
   _type: 'paragraph-section';
   title: string;
   paragraphs: ParagraphBlock[];
 };
 
-export type Section = ParagraphSection;
+export type ChartValue = {
+  label: string;
+  value: number;
+};
+
+export type SectionPieChart = SectionBase & {
+  _type: 'piechart-section';
+  title: string;
+  updatedAt: string;
+  values: ChartValue[];
+};
+
+export type Section = SectionParagraph | SectionPieChart;
 
 export type Page = {
   _id: string;


### PR DESCRIPTION
Added a section type to add pie charts

So far it's set to do percents, but might expand the unit at a later point if there's any need for it

## Preview of changes

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td><img width="638" alt="image" src="https://github.com/user-attachments/assets/54fd55ab-c731-4ada-b9ca-7c5d74c1165e" /></td>
        <td><img width="624" alt="image" src="https://github.com/user-attachments/assets/83d138fb-8a3c-4d0b-b202-d304de7244ad" /></td>
    </tr>
</table>

<table>
    <tr>
        <td>New sections</td>
    </tr>
    <tr>
        <td><img width="729" alt="image" src="https://github.com/user-attachments/assets/9eaa8084-6573-4d98-808a-3d2585dc8a2a" /></td>
    </tr>
    <tr><td><img width="633" alt="image" src="https://github.com/user-attachments/assets/de614043-c600-4d01-be74-b38d32235094" />
</td></tr>
    <tr><td><img width="634" alt="image" src="https://github.com/user-attachments/assets/f0d5cf33-0535-4161-9af4-0eaf74f26b02" /></td></tr>
</table>